### PR TITLE
Add default_content function

### DIFF
--- a/lib/puppet/parser/functions/default_content.rb
+++ b/lib/puppet/parser/functions/default_content.rb
@@ -1,0 +1,22 @@
+module Puppet::Parser::Functions
+  Puppet::Parser::Functions.newfunction(:default_content,
+                                        :type => :rvalue,
+                                        :doc => <<-'ENDOFDOC'
+  Takes an optional content and an optional template name to calculate the actual
+  contents of a file.
+
+  This small function abbreviates the default initialisation boilerplate of
+  stdmod modules.
+  ENDOFDOC
+  ) do |args|
+    content = args[0]
+    template_name = args[1]
+
+    Puppet::Parser::Functions.autoloader.loadall
+
+    return content if content != ''
+    return function_template(template_name) if template_name
+
+    return nil
+  end
+end


### PR DESCRIPTION
Wonder if you can be interested in merging this function, currently placed in https://github.com/stdmod/stdmod (a general module whose function is similar to extlib).
Wonder also if you are open to other similar contributions and eventually to the idea of merging the (partly similar) efforts of puppetcommunity and stdmod github orgs.

Usage example for the function:
```puppet
$config_file_template     = undef,
$config_file_content      = undef,

$real_config_file_content = default_content($config_file_content, $config_file_template)
```