### PR TITLE
Adds cache_data function for caching values on the master

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,6 +118,25 @@ echo($v7) # no comment here
 # My structure (Hash) {"b"=>["1", "2", "3"]}
 # (String) "12345"
 ```
+
+###cache_data
+
+Retrieves data from a cache file, or creates it with supplied data if the file doesn't exist. Useful for having data that's randomly generated once on the master side (e.g. a password), but then stays the same on subsequent runs. The `cache_data` takes three parameters:
+
+ * namespace: the folder under Puppet's vardir that the data is placed (e.g. mysql becomes /var/lib/puppet/mysql)
+ * data_name: the filename to store the data as (e.g. mysql_password becomes /var/lib/puppet/mysql/mysql_password)
+ * initial_data: the data to store and cache in the data_name file 
+
+*Examples:*
+
+```
+class mymodule::params {
+
+  $password = cache_data('mysql', 'mysql_password', 'this_is_my_password')
+
+}
+```
+
 ##Limitations
 
 This module requires puppetlabs-stdlib >=3.2.1, which is when `deep_merge()`

--- a/lib/puppet/parser/functions/cache_data.rb
+++ b/lib/puppet/parser/functions/cache_data.rb
@@ -1,0 +1,39 @@
+require 'fileutils'
+require 'yaml'
+require 'etc'
+
+# Retrieves data from a cache file, or creates it with supplied data if the file doesn't exist
+#
+# Useful for having data that's randomly generated once on the master side (e.g. a password), but
+# then stays the same on subsequent runs.
+#
+# Usage: cache_data(namespace, name, initial_data)
+# Example: $password = cache_data('mysql', 'mysql_password', 'this_is_my_password')
+module Puppet::Parser::Functions
+  newfunction(:cache_data, :type => :rvalue) do |args|
+    raise Puppet::ParseError, 'Usage: cache_data(namespace, name, initial_data)' unless args.size == 3
+
+    namespace = args[0]
+    raise Puppet::ParseError, 'Must provide namespace' if namespace.empty?
+
+    name = args[1]
+    raise Puppet::ParseError, 'Must provide data name' if name.empty?
+
+    initial_data = args[2]
+
+    cache_dir = File.join(Puppet[:vardir], namespace)
+    cache = File.join(cache_dir, name)
+
+    if File.exists? cache
+      YAML.load(File.read(cache))
+    else
+      FileUtils.mkdir_p(cache_dir)
+      File.open(cache, 'w', 0600) do |c|
+        c.write(YAML.dump(initial_data))
+      end
+      File.chown(File.stat(Puppet[:vardir]).uid, nil, cache)
+      File.chown(File.stat(Puppet[:vardir]).uid, nil, cache_dir)
+      initial_data
+    end
+  end
+end

--- a/spec/functions/cache_data_spec.rb
+++ b/spec/functions/cache_data_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'cache_data' do
+  include Mocha::ParameterMatchers
+
+  let(:initial_data) { 'my_password' }
+  let(:data_name) { 'mysql_password' }
+  let(:cache_dir) { 'data_cache' }
+  let(:filename) { "#{cache_dir}/#{data_name}" }
+
+  it { expect(subject).not_to eq(nil) }
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params(data_name).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params('', initial_data).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params('', 'mysql_password', initial_data).and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params(cache_dir, data_name, initial_data).and_return(initial_data) }
+
+  context 'when data already exists' do
+    before do
+      File.stubs(:read).with(regexp_matches(/metadata.json/)).returns('{}')
+      File.stubs(:exists?).with(regexp_matches(/#{filename}/)).returns(true)
+      File.expects(:read).with(regexp_matches(/#{filename}/)).returns(initial_data).once
+    end
+
+    it { is_expected.to run.with_params(cache_dir, data_name, initial_data).and_return(initial_data) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,11 @@
 #  Copyright 2014 Puppet Community
-#  
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#  
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Allows retrieving data from a cache file, or creates it with
supplied data if the file doesn't exist. This is useful for having
data that's randomly generated once on the master side (e.g. a password),
but then stays the same on subsequent runs.