### PR TITLE
fix (rvm) bring back 1.9.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.1.7


### PR DESCRIPTION
While we made the decision to drop 1.8.7, we *cannot* yet drop 1.9.3.
Too much depends on it, so we're bringing it back.