### PR TITLE
feat (release) more solid way to release (thru travis)

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,3 +5,5 @@ spec/spec_helper.rb:
   unmanaged: true
 Rakefile:
   unmanaged: true
+Gemfile:
+  unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'metadata-json-lint',                                         :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec',                                                      :require => false
-  gem 'puppet-blacksmith',                                          :require => false
+  gem 'puppet-blacksmith',                                          :require => false, :git => 'https://github.com/puppet-community/puppet-blacksmith.git'
   gem 'rubocop',                                                    :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppetlabs_spec_helper',                                     :require => false


### PR DESCRIPTION
remove Gemfile from sync for now, for we are using the latest (yet
unreleased) version of puppet-blacksmith. This version has
`module:bump:full` which allows us to fully specify the version, so no
more "manual" fiddling.

This version of travis_release also *rejects* releases that are RCs